### PR TITLE
Add Ability to Log Arbitrary Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ That includes:
 
 For more info see your ruby version's documentation for the `Logger` class.
 
+### Logging Additional Key/Value Pairs
+
+You can pass a second argument, a Hash that will end up as keys/values in the
+logged JSON.
+
+```ruby
+logger = NyplLogFormatter.new('path/to/file.log')
+
+logger.error(
+  'Something went wrong',
+  user: {email: 'simon@example.com', name: 'simon'},
+  permissions: ['admin', 'good-boy']
+)
+
+# Contents of file.log
+  # Logfile created on 2018-01-17 15:51:31 -0500 by logger.rb/61378
+  #{"level":"ERROR","message":"Something went wrong","timestamp":"2018-02-07T16:47:22.017-0500","user":{"email":"simon@example.com","name":"simon"},"permissions":["admin","good-boy"]}
+
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/nypl_log_formatter.rb
+++ b/lib/nypl_log_formatter.rb
@@ -10,17 +10,35 @@ class NyplLogFormatter < ::Logger
     super(*args)
     # This has to happen _after_ call to super, otherwise ::Logger will set the formatter
     set_formatter
+    allow_arbitrary_keys
   end
 
-private
+  private
+
+  # Redefines #log(), #error(), etc...but explodes the `progname` arg
+  # to be more than a simple string.
+  # See original implementations here: https://github.com/ruby/ruby/blob/trunk/lib/logger.rb#L524
+  def allow_arbitrary_keys
+    Logger::Severity.constants.each do |severity_name|
+      define_singleton_method(severity_name.to_s.downcase.to_sym) do |*progname, &block|
+        add(eval(severity_name.to_s), nil, progname, &block)
+      end
+    end
+  end
 
   def set_formatter
     self.formatter = proc do |severity, datetime, progname, msg|
       message_hash = {
         level:     severity.upcase,
-        message:   msg,
+        message:   msg.shift,
         timestamp: Time.now.strftime("%Y-%m-%dT%H:%M:%S.%L%z")
       }
+      msg.each do |additional_key_values|
+        additional_key_values.each do |key, value|
+          message_hash[key] = value
+        end
+      end
+
       "#{JSON.generate(message_hash)}\n"
     end
   end

--- a/lib/nypl_log_formatter.rb
+++ b/lib/nypl_log_formatter.rb
@@ -30,13 +30,20 @@ class NyplLogFormatter < ::Logger
     self.formatter = proc do |severity, datetime, progname, msg|
       message_hash = {
         level:     severity.upcase,
-        message:   msg.shift,
+        message:   msg.is_a?(Array) ? msg.shift : msg,
         timestamp: Time.now.strftime("%Y-%m-%dT%H:%M:%S.%L%z")
       }
-      msg.each do |additional_key_values|
-        additional_key_values.each do |key, value|
-          message_hash[key] = value
+
+      if msg.is_a?(Array)
+        msg.each do |additional_key_values|
+          additional_key_values.each do |key, value|
+            message_hash[key] = value
+          end
         end
+      end
+
+      if progname && !progname.empty?
+        message_hash['programName'] = progname[0]
       end
 
       "#{JSON.generate(message_hash)}\n"

--- a/spec/nypl_log_formatter_spec.rb
+++ b/spec/nypl_log_formatter_spec.rb
@@ -23,4 +23,18 @@ describe NyplLogFormatter do
 
     tmp.close
   end
+
+  it "can log arbirary keys" do
+    tmp = Tempfile.new('flyingsaucerattack')
+    logger = NyplLogFormatter.new(tmp)
+    logger.error(
+      'never hit your grandma with a shovel',
+      user: {email: 'simon@example.com', name: 'simon'}
+    )
+    tmp.rewind
+    parsed_log = JSON.parse(tmp.read)
+    expect(parsed_log['message']).to eq('never hit your grandma with a shovel')
+    expect(parsed_log['user']['email']).to eq('simon@example.com')
+    expect(parsed_log['user']['name']).to eq('simon')
+  end
 end

--- a/spec/nypl_log_formatter_spec.rb
+++ b/spec/nypl_log_formatter_spec.rb
@@ -45,4 +45,23 @@ describe NyplLogFormatter do
     # Logs a second key whos value is an Array
     expect(parsed_log['permissions']).to eq(['admin', 'good-boy'])
   end
+
+  it "works when logging message in a block" do
+    tmp = Tempfile.new('flyingsaucerattack')
+    logger = NyplLogFormatter.new(tmp)
+    logger.error {'never hit your grandma with a shovel'}
+    tmp.rewind
+    parsed_log = JSON.parse(tmp.read)
+    expect(parsed_log['message']).to eq('never hit your grandma with a shovel')
+  end
+
+  it "works when logging with progname" do
+    tmp = Tempfile.new('flyingsaucerattack')
+    logger = NyplLogFormatter.new(tmp)
+    logger.info('my_great_app') { "Initializing..." }
+    tmp.rewind
+    parsed_log = JSON.parse(tmp.read)
+    expect(parsed_log['message']).to eq('Initializing...')
+    expect(parsed_log['programName']).to eq('my_great_app')
+  end
 end

--- a/spec/nypl_log_formatter_spec.rb
+++ b/spec/nypl_log_formatter_spec.rb
@@ -29,12 +29,20 @@ describe NyplLogFormatter do
     logger = NyplLogFormatter.new(tmp)
     logger.error(
       'never hit your grandma with a shovel',
-      user: {email: 'simon@example.com', name: 'simon'}
+      user: {email: 'simon@example.com', name: 'simon'},
+      permissions: ['admin', 'good-boy']
     )
     tmp.rewind
     parsed_log = JSON.parse(tmp.read)
+
+    # Logs a plain-old message
     expect(parsed_log['message']).to eq('never hit your grandma with a shovel')
+
+    # Logs a key whose value is a hash/simple object
     expect(parsed_log['user']['email']).to eq('simon@example.com')
     expect(parsed_log['user']['name']).to eq('simon')
+
+    # Logs a second key whos value is an Array
+    expect(parsed_log['permissions']).to eq(['admin', 'good-boy'])
   end
 end


### PR DESCRIPTION
Our [logging guidelines](https://github.com/NYPL/engineering-general/blob/master/standards/logging.md) state:

> Additional key/values of any type MAY be included and MUST NOT break functionality.

This gives us that ability.