### PR TITLE
Remove version of bundler in dev dependencies

### DIFF
--- a/nypl_log_formatter.gemspec
+++ b/nypl_log_formatter.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "pry", '~> 0.11.3'
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'rspec', '~> 3.7'
 end


### PR DESCRIPTION
Depending on the version of Ruby, different bundler versions can be used.
Pegging to a specific version of bundler was breaking the test matrix in different versions of Ruby:

Example:
https://travis-ci.org/NYPL/ruby_nypl_log_formatter/builds/486706323